### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -11,7 +11,8 @@ pps-tools (1.0.2-2) unstable; urgency=medium
     Fixes lintian: package-uses-old-debhelper-compat-version
   * [54da43a] Change priority extra to priority optional.
     Fixes lintian: priority-extra-is-replaced-by-priority-optional
-  * [d3cbd02] debian/copyright: Use spaces rather than tabs in continuation lines.
+  * [d3cbd02] debian/copyright: Use spaces rather than tabs in continuation
+    lines.
   * [43f4d21] Set upstream metadata fields: Repository.
     Fixes lintian: upstream-metadata-file-is-missing
   * [fc48076] Use secure URI in Vcs control header.

--- a/debian/copyright
+++ b/debian/copyright
@@ -31,4 +31,4 @@ License: GPL-2+
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
   .
   On Debian systems, the complete text of the GNU General
-  Public License can be found in `/usr/share/common-licenses/GPL'.
+  Public License can be found in `/usr/share/common-licenses/GPL-2'.

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,1 +1,4 @@
-Repository: https://github.com/redlab-i/pps-tools
+Bug-Database: https://github.com/redlab-i/pps-tools/issues
+Bug-Submit: https://github.com/redlab-i/pps-tools/issues/new
+Repository: https://github.com/redlab-i/pps-tools.git
+Repository-Browse: https://github.com/redlab-i/pps-tools


### PR DESCRIPTION
Fix some issues reported by lintian
* Wrap long lines in changelog entries: 1.0.2-2. ([debian-changelog-line-too-long](https://lintian.debian.org/tags/debian-changelog-line-too-long.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Refer to specific version of license GPL-2+. ([copyright-refers-to-symlink-license](https://lintian.debian.org/tags/copyright-refers-to-symlink-license.html), [copyright-refers-to-versionless-license-file](https://lintian.debian.org/tags/copyright-refers-to-versionless-license-file.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/pps-tools/5c3569c7-b5a3-4d8b-9a85-7f36ca824b6f.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/5c3569c7-b5a3-4d8b-9a85-7f36ca824b6f/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/5c3569c7-b5a3-4d8b-9a85-7f36ca824b6f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/5c3569c7-b5a3-4d8b-9a85-7f36ca824b6f/diffoscope)).
